### PR TITLE
Simplify api usage

### DIFF
--- a/conversion.py
+++ b/conversion.py
@@ -1,0 +1,29 @@
+import ast
+
+# This file includes helper functions to convert values to and from strings
+# and to and from the robot's internal representation of values.
+
+
+def to_string(value):
+    """
+    Converts a value to a string that can be sent to the robot
+
+        e.g. [1, 2, 3] -> "[1, 2, 3]", 1.0 -> "1.0", True -> "True"
+
+    """
+    return value.__str__()
+
+
+def from_string(value):
+    """
+    Converts a string received from the robot to a specific type,
+
+        e.g. "[1, 2, 3]" -> [1, 2, 3], "1.0" -> 1.0, "TRUE" -> True
+
+    If the type cannot be determined, the value is returned as a string
+
+    You can use type hints to specify the type of the returned value:
+
+        coords: List[float] = from_string(value)
+    """
+    return ast.literal_eval(value.replace("TRUE", "True").replace("FALSE", "False"))

--- a/example.py
+++ b/example.py
@@ -28,9 +28,11 @@ class Example:
                 y = 100 + random.random() * 300
                 z = 0 + random.random() * 300
 
+                coords = [x, y, z]
+
                 # Set the updated position in the robot
-                robcomm.set_rapid_variable(ROBOT_POS, f"[{x}, {y}, {z}]")
-                
+                robcomm.set_rapid_variable(ROBOT_POS, coords)
+
                 # Signal that the robot is not in position
                 robcomm.set_rapid_variable(ROBOT_IN_POSITION, False)
             case Example.POS:

--- a/example.py
+++ b/example.py
@@ -1,11 +1,14 @@
 import robcomm
 import random
+import conversion as conv
 
 ROBOT_POS = "T_ROB1/Module1/position"
 ROBOT_IN_POSITION = "T_ROB1/Module1/in_position"
 
+
 def url_for_variable(variable) -> str:
     return f"/rw/rapid/symbol/RAPID/{variable}/data"
+
 
 class Example:
     IN_POSITION = url_for_variable(ROBOT_IN_POSITION)
@@ -15,14 +18,15 @@ class Example:
     def on_message(self, robcomm: robcomm.Robot, variable_url: str, value):
         match variable_url:
             case Example.IN_POSITION:
-                if value == "FALSE":
+                in_pos: bool = conv.from_string(value)
+                if not in_pos:
                     # Ignore the message if the robot is not in position
                     print("Robot is moving")
                     return
-                if value == "TRUE":
+                if in_pos:
                     new_pos = robcomm.get_rapid_variable(variable=ROBOT_POS)
                     print(f"Robot is in position {new_pos}")
-                
+
                 # Create new random x, y and z values
                 x = 100 + random.random() * 300
                 y = 100 + random.random() * 300
@@ -36,14 +40,14 @@ class Example:
                 # Signal that the robot is not in position
                 robcomm.set_rapid_variable(ROBOT_IN_POSITION, False)
             case Example.POS:
-                print(f"Position {variable_url} changed to {value}, {robcomm.ip}")
+                coords: list[float] = conv.from_string(value)
+                print(f"Position {variable_url} changed to {coords}, {robcomm.ip}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Create a connection to the robot
-    robot = robcomm.Robot(ip='127.0.0.1', port=9933)
+    robot = robcomm.Robot(ip="127.0.0.1", port=9933)
     # Create a local example object to handle the messages
     example = Example()
     # Subscribe to the in_position and position variables, and call the on_message function when a message is received
     robot.subscribe([ROBOT_IN_POSITION, ROBOT_POS], example.on_message)
-    
-

--- a/robcomm.py
+++ b/robcomm.py
@@ -182,11 +182,15 @@ class Robot:
         pp(self.__GET("/rw/rapid/tasks/" + task_name + "/modules/" + module_name + "/routine" + "?row=0&column=0"))
 
     def set_rapid_variable(self, variable, value):
-        """ 
+        """
         Set a Rapid Variable with the given value.\n
         The variable must be a string in the format `task_name/module_name/variable_name`
         """
-        self.__POST("/rw/rapid/symbol/RAPID/" + variable + "/data?mastership=implicit", data={"value": value})
+        value = '"' + value + '"' if isinstance(value, str) else value.__str__()
+        self.__POST(
+            "/rw/rapid/symbol/RAPID/" + variable + "/data?mastership=implicit",
+            data={"value": value},
+        )
 
     def get_rapid_variable(self, url=None, variable=None) -> str:
         if url is None:

--- a/robcomm.py
+++ b/robcomm.py
@@ -12,37 +12,38 @@ from ws4py.messaging import TextMessage
 from models import Task, Module
 import urllib3
 from dacite import from_dict
+
 urllib3.disable_warnings()
 
 
-HOST = '127.0.0.1'
+HOST = "127.0.0.1"
 # Jacobi
-USER = 'Admin'
+USER = "Admin"
 # alt 'Default User'
-PWD = 'robotics'
+PWD = "robotics"
 
 basic_auth = HTTPBasicAuth(USER, PWD)
 
-FORMAT = '%(asctime)-15s - %(message)s'
-logging.basicConfig(format=FORMAT,level=logging.DEBUG)
-logger = logging.getLogger('ability_tool')
+FORMAT = "%(asctime)-15s - %(message)s"
+logging.basicConfig(format=FORMAT, level=logging.CRITICAL)
+logger = logging.getLogger("ability_tool")
 
 
 class RobWebSocketClient(WebSocketClient):
     def __init__(self, url, headers, api, on_message=None):
-        super().__init__(url,protocols=['rws_subscription'], headers=headers)
+        super().__init__(url, protocols=["rws_subscription"], headers=headers)
         self.on_message: callable = on_message
         self.api: Robot = api
-        self.namespace = '{http://www.w3.org/1999/xhtml}'
+        self.namespace = "{http://www.w3.org/1999/xhtml}"
         self.variables = []
 
     def opened(self):
-        logger.info('Opened Websocket')
+        logger.info("Opened Websocket")
 
     def closed(self, code, reason=None):
         self.api.logout()
         self.close_connection()
-        logger.info('Closed Websocket')
+        logger.info("Closed Websocket")
 
     def received_message(self, message: TextMessage):
         if not message.is_text:
@@ -50,7 +51,9 @@ class RobWebSocketClient(WebSocketClient):
         root = ET.fromstring(message.data.decode("utf-8"))
         # Find variable url in message
         if root.findall(".//{0}li[@class='rap-value-ev']".format(self.namespace)):
-            url = root.find(".//{0}li[@class='rap-value-ev']/{0}a".format(self.namespace)).attrib['href']
+            url = root.find(
+                ".//{0}li[@class='rap-value-ev']/{0}a".format(self.namespace)
+            ).attrib["href"]
             if not url:
                 print("No url found in message")
                 return
@@ -71,27 +74,38 @@ class RobWebSocketClient(WebSocketClient):
         finally:
             self.close()
 
+
 class Robot:
-    def __init__(self, ip="152.94.0.228", user='Default User', pwd='robotics', port=443, proto='https://'):
-        self.header = {'Accept':'application/hal+json;v=2.0','Content-Type': 'application/x-www-form-urlencoded;v=2.0'}
+    def __init__(
+        self,
+        ip="152.94.0.228",
+        user="Default User",
+        pwd="robotics",
+        port=443,
+        proto="https://",
+    ):
+        self.header = {
+            "Accept": "application/hal+json;v=2.0",
+            "Content-Type": "application/x-www-form-urlencoded;v=2.0",
+        }
         self.ip = ip
         self.port = port
         self.proto = proto
         self.user = user
         self.pwd = pwd
-        self.cookie = ''
-        self.url = self.proto + self.ip + ':' + str(self.port)
+        self.cookie = ""
+        self.url = self.proto + self.ip + ":" + str(self.port)
         self.conn = requests.Session()
         self.has_mastership = False
         self.login()
 
     def __str__(self):
         s = 'The object of class "Robot" contains:\n'
-        s+= f'\tIP: "{self.ip}"\n'
-        s+= f'\tport:{self.port}\n'
-        s+= f'\tuser:{self.user}\n'
-        s+= f'\tpwd:{self.pwd}\n'
-        s+= f'\theader:{self.header}\n'
+        s += f'\tIP: "{self.ip}"\n'
+        s += f"\tport:{self.port}\n"
+        s += f"\tuser:{self.user}\n"
+        s += f"\tpwd:{self.pwd}\n"
+        s += f"\theader:{self.header}\n"
         return s
 
     def __POST(self, rq, data=None):
@@ -100,37 +114,46 @@ class Robot:
     def __GET(self, rq):
         return self.__request("GET", rq)
 
-    def __request(self, method, rq='', data=None):
+    def __request(self, method, rq="", data=None):
         try:
             url = self.url + rq
             match method:
-                case 'GET':
-                    resp = self.conn.get(url, headers=self.header, auth=basic_auth, verify=False)
+                case "GET":
+                    resp = self.conn.get(
+                        url, headers=self.header, auth=basic_auth, verify=False
+                    )
                     if len(resp.content) > 0:
                         return json.loads(resp.content), resp.status_code
                     else:
                         return None, resp.status_code
-                case 'POST':
-                    resp = self.conn.post(url, data=data, headers=self.header, auth=basic_auth, verify=False)
+                case "POST":
+                    resp = self.conn.post(
+                        url,
+                        data=data,
+                        headers=self.header,
+                        auth=basic_auth,
+                        verify=False,
+                    )
                 case _:
                     raise Exception("Method not supported")
 
-
         except Exception as error:
             logger.error(f"Error: {error}")
-        
+
         return None, None
 
     def login(self):
-            resp = self.conn.post(self.url, auth=basic_auth, headers=self.header, verify=False)
-            logger.info('Login: Done!')
-            session = resp.cookies['-http-session-']
-            ABBCX = resp.cookies['ABBCX']
-            self.cookie = f'-http-session-={session}; ABBCX={ABBCX}'
-            logger.info('Cookie: %s', self.cookie)
+        resp = self.conn.post(
+            self.url, auth=basic_auth, headers=self.header, verify=False
+        )
+        logger.info("Login: Done!")
+        session = resp.cookies["-http-session-"]
+        ABBCX = resp.cookies["ABBCX"]
+        self.cookie = f"-http-session-={session}; ABBCX={ABBCX}"
+        logger.info("Cookie: %s", self.cookie)
 
     def logout(self):
-        _, code = self.__GET('/logout')
+        _, code = self.__GET("/logout")
         logger.info(f"Logout: {code}")
 
     def list_rapid_variables(self):
@@ -143,6 +166,7 @@ class Robot:
             else:
                 logger.info("You do not have mastership")
                 return
+
         return wrapper
 
     def requires_manual_mode(self, func: callable):
@@ -151,13 +175,14 @@ class Robot:
                 return func(self, *args, **kwargs)
             else:
                 logger.info("You do not have mastership")
+
         return wrapper
 
     def get_tasks(self) -> list:
         content, code = self.__GET("/rw/rapid/tasks")
         # Unmarshal the received JSON into a list of Task objects
         tasks = []
-        for task in content['_embedded']['resources']:
+        for task in content["_embedded"]["resources"]:
             tasks.append(from_dict(Task, task))
         return tasks
 
@@ -165,10 +190,10 @@ class Robot:
         content, code = self.__GET("/rw/rapid/tasks/" + task_name + "/modules")
         # Unmarshal the received JSON into a list of Module objects
         modules = []
-        for module in content['state']:
+        for module in content["state"]:
             modules.append(from_dict(Module, module))
         return modules
-    
+
     def get_task_service_routines(self, task_name) -> list:
         pp(self.__GET("/rw/rapid/tasks/" + task_name + "/serviceroutine"))
 
@@ -176,10 +201,23 @@ class Robot:
         pp(self.__GET("/rw/rapid/tasks/" + task_name + "/modules/" + module_name))
 
     def get_module_symbol(self, task_name, module_name) -> list:
-        pp(self.__GET("/rw/rapid/tasks/" + task_name + "/modules/" + module_name + "/symbol"))
+        pp(
+            self.__GET(
+                "/rw/rapid/tasks/" + task_name + "/modules/" + module_name + "/symbol"
+            )
+        )
 
     def get_module_routines(self, task_name, module_name) -> list:
-        pp(self.__GET("/rw/rapid/tasks/" + task_name + "/modules/" + module_name + "/routine" + "?row=0&column=0"))
+        pp(
+            self.__GET(
+                "/rw/rapid/tasks/"
+                + task_name
+                + "/modules/"
+                + module_name
+                + "/routine"
+                + "?row=0&column=0"
+            )
+        )
 
     def set_rapid_variable(self, variable, value):
         """
@@ -217,44 +255,50 @@ class Robot:
             self.has_mastership = False
             logger.info("You have released mastership")
 
-    def subscribe(self, variables: list[str], on_message: callable=None):
+    def subscribe(self, variables: list[str], on_message: callable = None):
         """
-            Subscribes to the given variables and calls the on_message function when a message is received.
-            The `on_message` function receives the updated value of the variable.
+        Subscribes to the given variables and calls the on_message function when a message is received.
+        The `on_message` function receives the updated value of the variable.
 
-            @param variables: The variables to subscribe to. Each variable must be a valid *path* to a RAPID variable.
-            Example: `T_ROB1/main/Flag` for the variable `Flag` in the task `T_ROB1` in the `main` module.
-            
-            @param on_message: The function to call when a message is received.
-            The function passed must accept one parameter, the updated value of the variable.
+        @param variables: The variables to subscribe to. Each variable must be a valid *path* to a RAPID variable.
+        Example: `T_ROB1/main/Flag` for the variable `Flag` in the task `T_ROB1` in the `main` module.
+
+        @param on_message: The function to call when a message is received.
+        The function passed must accept one parameter, the updated value of the variable.
         """
 
         # Variable API endpoint
         payload = {}
-        payload['resources'] = [str(i) for i in range(1, len(variables) + 1)]
+        payload["resources"] = [str(i) for i in range(1, len(variables) + 1)]
         for i, variable in enumerate(variables):
             uri = "/rw/rapid/symbol/RAPID/" + variable + "/data;value"
             payload[str(i + 1)] = uri
-            payload[f'{i + 1}-p'] = '1'
+            payload[f"{i + 1}-p"] = "1"
 
         print(payload)
         try:
-            resp = self.conn.post(self.url + '/subscription', headers=self.header, auth=basic_auth, data=payload)
+            resp = self.conn.post(
+                self.url + "/subscription",
+                headers=self.header,
+                auth=basic_auth,
+                data=payload,
+            )
 
             # Status code 201 means that the subscription was successful
             if resp.status_code != 201:
                 # If the subscription failed, log the error and exit
-                logger.info('Error: %s', resp.status_code)
+                logger.info("Error: %s", resp.status_code)
                 return
-            logger.info('Successfully subscribed to %s', variable)
-            websock_headers = [('Cookie', self.cookie)]
-            
+            logger.info("Successfully subscribed to %s", variable)
+            websock_headers = [("Cookie", self.cookie)]
+
             # Initialize and start the websocket
-            robwebscoket = RobWebSocketClient(resp.headers['location'], websock_headers, self, on_message=on_message)
+            robwebscoket = RobWebSocketClient(
+                resp.headers["location"], websock_headers, self, on_message=on_message
+            )
             for variable in variables:
                 robwebscoket.variables.append(variable)
             robwebscoket.start()
 
         except Exception as error:
-            logger.exception('Error: %s', error)
-
+            logger.exception("Error: %s", error)


### PR DESCRIPTION
This PR changes how values are sent with the API.

Previously users would have to convert values to their string representation before setting them with `set_rapid_variable`, e.g.:

```py
True -> "TRUE"
[1, 2, 3] -> "[1, 2, 3]"
set_rapid_variable(ROBOT_VARIABLE, "[1, 2, 3]")
```

The change introduced in this PR removes the burden on the user to convert the variable. Instead, `set_rapid_variable` converts all values to their string representation before passing them on to the robot.

```py
set_rapid_variable(ROBOT_VARIABLE, [1, 2, 3])
```

The value returned from `get_rapid_variable` may be converted to its original type by passing it to the `from_string` method found in `conversion.py`.

```python
# value = "TRUE"
in_position = conv.from_string(value) # returns True as Any
typed_in_position: bool = conv.from_string(value) # returns True as bool
```